### PR TITLE
Reduce contact-form spam with honeypot + no-solicitations notice

### DIFF
--- a/app/api/contact/route.js
+++ b/app/api/contact/route.js
@@ -8,6 +8,11 @@ export async function POST(request) {
   const name = String(formData.get("name") || "").trim();
   const replyTo = String(formData.get("_replyto") || "").trim();
   const message = String(formData.get("message") || "").trim();
+  const honeypot = String(formData.get("website") || "").trim();
+
+  if (honeypot) {
+    return NextResponse.redirect(new URL("/thanks", request.url), 303);
+  }
 
   try {
     await resend.emails.send({

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -83,6 +83,31 @@ export default async function ContactPage({ searchParams }) {
                   required
                 ></textarea>
               </div>
+              <div
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  left: "-9999px",
+                  width: "1px",
+                  height: "1px",
+                  overflow: "hidden",
+                }}
+              >
+                <label htmlFor="websiteInput">
+                  Leave this field blank
+                </label>
+                <input
+                  type="text"
+                  name="website"
+                  id="websiteInput"
+                  tabIndex={-1}
+                  autoComplete="off"
+                />
+              </div>
+              <p className="text-muted" style={{ fontSize: "0.9em" }}>
+                This form is for prospective clients only. No solicitations,
+                vendor pitches, or marketing outreach, please.
+              </p>
               <button type="submit" className="learn-more-btn">
                 Submit
               </button>


### PR DESCRIPTION
## Summary
- Adds a visually-hidden `website` honeypot field to the contact form; submissions that fill it are silently redirected to `/thanks` without sending email, so naive bots don't know they were caught.
- Adds a brief "no solicitations" notice above the submit button to set expectations for humans and deter low-effort cold outreach.

Closes #2. Implements the proposed first pass from the issue (options 1 + 5). If spam persists after a couple weeks, next logical layer is Vercel BotID (native, invisible, no third-party script).

## Test plan
- [ ] Submit the form normally → email arrives, redirect to `/thanks`.
- [ ] Inspect the form and set a value on the hidden `website` input, then submit → redirect to `/thanks`, but no email is sent.
- [ ] Honeypot field is not visible, not focusable via Tab, and ignored by screen readers (`aria-hidden`, off-screen positioning, `tabIndex={-1}`).
- [ ] "No solicitations" notice renders above the submit button on desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)